### PR TITLE
[Login] path exposed.

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -86,17 +86,13 @@ const App: FC = () => {
               </Unumid>
           }
           />
-          {/* <Route path='/login'>
-            <Unumid>
-              <Login />
-            </Unumid>
-          </Route>
-          <Route path='/authenticated'>
-            <Acme>
-              <AltHeader />
-              <Authenticated />
-            </Acme>
-          </Route> */}
+          <Route
+            path='/login' element={
+              <Unumid>
+                <Login />
+              </Unumid>
+          }
+          />
           <Route
             path='/proveAuth' element={
               <Acme>


### PR DESCRIPTION
But not really hooked up. Just let the login button on the request QR to take one somewhere. This probably ought to be setup to actually auth with the acme demo so one can get emails/sms presentation requests. 